### PR TITLE
Fix empty cloze words and preserve trailing punctuation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,5 @@
 members = [
     "minicloze-cli",
     "minicloze-lib",
-    "minicloze-gui",
 ]
 resolver = "2"

--- a/minicloze-cli/src/main.rs
+++ b/minicloze-cli/src/main.rs
@@ -92,10 +92,26 @@ async fn start_game(
     for sentence in sentences {
         let prompt = sentence.generate_prompt(&language, inverse);
 
+        let clean_word = remove_punctuation(&prompt.word);
+        // Extract trailing punctuation characters from the end of the raw word
+        // Includes French whitespace: NBSP (U+00A0), thin space (U+2009), narrow no-break space (U+202F)
+        const PUNCTUATION: [char; 18] = [
+            '(', ')', ',', '.', ';', ':', '?', '¿', '!', '¡', '"', '«', '»', '。', ' ',
+            '\u{00A0}', '\u{2009}', '\u{202F}',
+        ];
+        let trailing_punct: String = prompt.word
+            .chars()
+            .rev()
+            .take_while(|c| PUNCTUATION.contains(c))
+            .collect::<String>()
+            .chars()
+            .rev()
+            .collect();
+
         let underscores_num = if inverse {
             String::from("?")
         } else {
-            vec!['_'; prompt.word.chars().count()]
+            vec!['_'; clean_word.chars().count()]
                 .into_iter()
                 .collect::<String>()
         };
@@ -138,7 +154,7 @@ async fn start_game(
                 )
             }
 
-            print!("{color_black}{bg_bright_white}{underscores_num}{style_reset}");
+            print!("{color_black}{bg_bright_white}{underscores_num}{trailing_punct}{style_reset}");
 
             for word in prompt.second_half.split(' ') {
                 print!(
@@ -163,33 +179,25 @@ async fn start_game(
 
         let levenshtein_distance = levenshtein(
             &remove_punctuation(&guess.trim().to_lowercase()),
-            prompt.word.to_lowercase().trim(),
+            &clean_word.to_lowercase(),
         );
 
+        let clean_word_lower = clean_word.to_lowercase();
         if levenshtein_distance == 0 {
             correct += 1;
             println!(
                 "Correct, {color_white}{bg_green}{}{color_reset}{bg_reset}",
-                Link::new(
-                    prompt.word.to_lowercase().trim(),
-                    &generate_url(prompt.word.to_lowercase().trim(), &language)
-                )
+                Link::new(&clean_word_lower, &generate_url(&clean_word_lower, &language))
             );
         } else if levenshtein_distance < DISTANCE_FOR_CLOSE as usize {
             println!(
                 "Close, {style_bold}{color_bright_white}{bg_yellow}{}{bg_reset}{color_reset}{style_reset}.",
-                Link::new(
-                    prompt.word.to_lowercase().trim(),
-                    &generate_url(prompt.word.to_lowercase().trim(), &language)
-                )
+                Link::new(&clean_word_lower, &generate_url(&clean_word_lower, &language))
             );
         } else {
             println!(
                 "Wrong, {style_bold}{color_bright_white}{bg_red}{}{bg_reset}{color_reset}{style_reset}.",
-                Link::new(
-                    prompt.word.to_lowercase().trim(),
-                    &generate_url(prompt.word.to_lowercase().trim(), &language)
-                )
+                Link::new(&clean_word_lower, &generate_url(&clean_word_lower, &language))
             );
         }
         println!();

--- a/minicloze-lib/src/sentence.rs
+++ b/minicloze-lib/src/sentence.rs
@@ -73,13 +73,28 @@ impl Sentence {
     // splits a sentence into a prompt consisting of three parts
     pub fn generate_prompt(&self, language: &str, inverse: bool) -> Prompt {
         let words: Vec<String> = self.as_words(language, inverse);
-        let halved = words.split_at(thread_rng().gen_range(0..words.len()));
 
-        let word = remove_punctuation(&halved.1[0]);
+        // Find indices of words that have actual content after punctuation removal
+        // (filters out whitespace-only "words" from double spaces, etc.)
+        let valid_indices: Vec<usize> = words
+            .iter()
+            .enumerate()
+            .filter(|(_, w)| !remove_punctuation(w).trim().is_empty())
+            .map(|(i, _)| i)
+            .collect();
+
+        // Pick from valid indices, or fallback to any index if none are valid
+        let split_index = if valid_indices.is_empty() {
+            thread_rng().gen_range(0..words.len())
+        } else {
+            valid_indices[thread_rng().gen_range(0..valid_indices.len())]
+        };
+
+        let halved = words.split_at(split_index);
 
         Prompt {
             first_half: halved.0.join(""),
-            word,
+            word: halved.1[0].clone(), // keep raw word with punctuation
             second_half: halved.1[1..].join(""),
         }
     }
@@ -135,9 +150,11 @@ pub fn parse(results: &str) -> Result<Vec<Sentence>, String> {
 }
 
 pub fn remove_punctuation(word: &str) -> String {
+    // Includes French whitespace: NBSP (U+00A0), thin space (U+2009), narrow no-break space (U+202F)
     word.replace(
         &[
             '(', ')', ',', '.', ';', ':', '?', '¿', '!', '¡', '"', '«', '»', '。', ' ',
+            '\u{00A0}', '\u{2009}', '\u{202F}',
         ][..],
         "",
     )


### PR DESCRIPTION
## Summary

- Fix bug where French sentences with space before punctuation (e.g., `C'est vrai ?`) could result in empty cloze words
- Fix bug where trailing punctuation on selected words was lost in display
- Remove non-existent `minicloze-gui` from workspace members

## Problem

**Bug 1: Empty cloze words**
French typography puts spaces before `?`, `!`, `:`, `;`. This causes `split_inclusive(' ')` to create standalone punctuation "words". When randomly selected, `remove_punctuation("?")` returns `""`, resulting in:
- No underscores displayed
- Empty input matches as "Correct"

**Bug 2: Lost punctuation**
Words like `moment.` had their punctuation stripped entirely. The period was part of the selected word but removed for answer matching, and never appeared in `second_half`.

## Solution

1. Filter out words that become empty after `remove_punctuation` before random selection
2. Store raw word (with punctuation) in Prompt, extract trailing punctuation for display, use clean word only for answer comparison

## Test plan

- [x] Tested with `minicloze french` - sentences now always show proper blanks
- [x] Trailing punctuation (periods, question marks) preserved in display
- [x] Answer matching still ignores punctuation

🤖 Generated with [Claude Code](https://claude.ai/code)